### PR TITLE
Update to play-json/play-iteratees 2.3.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,8 @@ val logbackVer = "1.0.9"
 libraryDependencies ++= Seq(
             //"org.scalaz.stream" %% "scalaz-stream" % "0.3.1",
             "com.netaporter" %% "scala-uri" % "0.4.2",
-            "com.typesafe.play" %% "play-json" % "2.3.8",
-            "com.typesafe.play" %% "play-iteratees" % "2.3.8",
+            "com.typesafe.play" %% "play-json" % "2.3.10",
+            "com.typesafe.play" %% "play-iteratees" % "2.3.10",
             // "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT",
             "net.databinder.dispatch" %% "dispatch-core" % "0.11.2",
             "org.specs2" %% "specs2" % "2.4.2" % "test",


### PR DESCRIPTION
play-json/play-iteratees 2.3.8 seem not to be available any more. Also, the artifact available in Sonatype Snapshots still depends on 2.3.4 so you have to add dependencyOverrides to be able to use this. Could you please publish a new Snapshot?
